### PR TITLE
Get Version, Commit and Date from build

### DIFF
--- a/build/vars.go
+++ b/build/vars.go
@@ -1,8 +1,0 @@
-package build
-
-// ldflags vars
-var (
-	Version string
-	Commit  string
-	Date    string
-)

--- a/build/version.go
+++ b/build/version.go
@@ -1,0 +1,30 @@
+package build
+
+import (
+	goversion "github.com/caarlos0/go-version"
+)
+
+// vars could be modified with ldflags
+var (
+	Version = "devel"
+	Commit  = ""
+	Date    = ""
+)
+
+func GetBuildInfos() goversion.Info {
+	return goversion.GetVersionInfo(
+		func(i *goversion.Info) {
+			if Commit != "" {
+				i.GitCommit = Commit
+			}
+			if Date != "" {
+				i.BuildDate = Date
+			}
+			if Version != "devel" {
+				i.GitVersion = Version
+			}
+		},
+	)
+}
+
+var BuildInfos = GetBuildInfos()

--- a/commons/const.go
+++ b/commons/const.go
@@ -2,9 +2,10 @@ package commons
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/mitchellh/colorstring"
 	"github.com/yodamad/heimdall/build"
-	"os"
 )
 
 var DefaultFolderFunc = func() string { home, _ := os.UserHomeDir(); return home + "/.heimdall/" }
@@ -56,7 +57,7 @@ var HelpMessageTemplate = colorstring.Color(`[light_blue]            _          
 / __  /  __/ | | | | | | (_| | (_| | | |
 \/ /_/ \___|_|_| |_| |_|\__,_|\__,_|_|_|
 
-[default]`) + fmt.Sprintf(colorstring.Color("Version [bold][light_gray]%s[reset]\n"), build.Version) + colorstring.Color(`
+[default]`) + fmt.Sprintf(colorstring.Color("Version [bold][light_gray]%s[reset]\n"), build.BuildInfos.GitVersion) + colorstring.Color(`
 [bold]Usage[reset]:{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.1.4 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/caarlos0/go-version v0.2.0 // indirect
 	github.com/charmbracelet/x/ansi v0.7.0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/cloudflare/circl v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/caarlos0/go-version v0.2.0 h1:TTD5dF3PBAtRHbfCKRE173SrVVpbE0yX95EDQ4BwTGs=
+github.com/caarlos0/go-version v0.2.0/go.mod h1:X+rI5VAtJDpcjCjeEIXpxGa5+rTcgur1FK66wS0/944=
 github.com/charmbracelet/bubbles v0.20.0 h1:jSZu6qD8cRQ6k9OMfR1WlM+ruM8fkPWkHvQWD9LIutE=
 github.com/charmbracelet/bubbles v0.20.0/go.mod h1:39slydyswPy+uVOHZ5x/GjwVAFkCsV8IIVy+4MhzwwU=
 github.com/charmbracelet/bubbletea v1.1.1 h1:KJ2/DnmpfqFtDNVTvYZ6zpPFL9iRCRr0qqKOCvppbPY=

--- a/utils/print.go
+++ b/utils/print.go
@@ -2,19 +2,20 @@ package utils
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/mitchellh/colorstring"
 	"github.com/yodamad/heimdall/build"
 	"github.com/yodamad/heimdall/cmd/entity"
 	"github.com/yodamad/heimdall/commons"
-	"os"
-	"strings"
 )
 
 func PrintBanner() {
 	fmt.Print(colorstring.Color(
-		`[light_blue]            _               _       _ _ 
+		`[light_blue]            _               _       _ _
   /\  /\___(_)_ __ ___   __| | __ _| | |
  / /_/ / _ \ | '_ ` + "`" + ` _ \ / _` + "`" + ` |/ _` + "`" + ` | | |
 / __  /  __/ | | | | | | (_| | (_| | | |
@@ -24,7 +25,8 @@ func PrintBanner() {
 	))
 
 	if commons.Verbose {
-		fmt.Printf(colorstring.Color("Version [bold][light_gray]%s[reset] (commit %s), built at %s\n"), build.Version, build.Commit, build.Date)
+		fmt.Printf(colorstring.Color("Version [bold][light_gray]%s[reset] (commit %s), built at %s\n"),
+			build.BuildInfos.GitVersion, build.BuildInfos.GitCommit[:7], build.BuildInfos.BuildDate)
 	} else {
 		fmt.Printf(colorstring.Color("Version [bold][light_gray]%s[reset]\n"), build.Version)
 	}

--- a/utils/print.go
+++ b/utils/print.go
@@ -25,8 +25,8 @@ func PrintBanner() {
 	))
 
 	if commons.Verbose {
-		fmt.Printf(colorstring.Color("Version [bold][light_gray]%s[reset] (commit %s), built at %s\n"),
-			build.BuildInfos.GitVersion, build.BuildInfos.GitCommit[:7], build.BuildInfos.BuildDate)
+		fmt.Printf(colorstring.Color("Version [bold][light_gray]%s[reset] (commit %s), built at %s, compiled with %s\n"),
+			build.BuildInfos.GitVersion, build.BuildInfos.GitCommit[:7], build.BuildInfos.BuildDate, build.BuildInfos.GoVersion)
 	} else {
 		fmt.Printf(colorstring.Color("Version [bold][light_gray]%s[reset]\n"), build.Version)
 	}


### PR DESCRIPTION
- use [github.com/caarlos0/go-version/](https://github.com/caarlos0/go-version/) module to get Commit and build Date from build infos embedded in binary
- rename `build/vars.go` -> `build/version.go`
- set default `Version` to `"devel"` in `build/version.go`
- modify outputs (default and verbose mode) to display these vars
- `utils/print.go`: in verbose mode, display Go compiler version used to build heimdall

Closes yodamad/heimdall#15

---

Outputs with these infos:
```shell
$ ./heimdall foo
            _               _       _ _
  /\  /\___(_)_ __ ___   __| | __ _| | |
 / /_/ / _ \ | '_ ` _ \ / _` |/ _` | | |
/ __  /  __/ | | | | | | (_| | (_| | | |
\/ /_/ \___|_|_| |_| |_|\__,_|\__,_|_|_|

Version devel

$ ./heimdall -v foo
            _               _       _ _
  /\  /\___(_)_ __ ___   __| | __ _| | |
 / /_/ / _ \ | '_ ` _ \ / _` |/ _` | | |
/ __  /  __/ | | | | | | (_| | (_| | | |
\/ /_/ \___|_|_| |_| |_|\__,_|\__,_|_|_|

Version devel (commit b87868c), built at 2025-01-24T17:30:17, compiled with go1.23.5
```

Vars in `build/version.go` can be modified via `ldflags` during build:
```shell
$ go build -v -ldflags "-X 'github.com/yodamad/heimdall/build.Version=VERSION_TEST'"

$ ./heimdall foo
            _               _       _ _
  /\  /\___(_)_ __ ___   __| | __ _| | |
 / /_/ / _ \ | '_ ` _ \ / _` |/ _` | | |
/ __  /  __/ | | | | | | (_| | (_| | | |
\/ /_/ \___|_|_| |_| |_|\__,_|\__,_|_|_|

Version VERSION_TEST
```

