### PR TITLE
Fix path for logs file on Linux

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/mitchellh/colorstring"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/yodamad/heimdall/cmd"
 	"github.com/yodamad/heimdall/commons"
 	"github.com/yodamad/heimdall/utils"
-	"os"
 )
 
 var rootCmd = &cobra.Command{
@@ -34,7 +35,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&commons.WorkDir, "work-dir", "w", commons.DefaultWorkDir, "work directory")
 	rootCmd.PersistentFlags().StringVarP(&commons.InputConfigFile, "config-file", "c", commons.InputConfigFile, "config file")
 
-	// Init .heimdall folder
+	// Create directory for configuration
 	_, err := os.Stat(commons.DefaultConfFolder)
 	if os.IsNotExist(err) {
 		err := os.Mkdir(commons.DefaultConfFolder, os.ModePerm)
@@ -49,7 +50,7 @@ func init() {
 	})
 	// Output to stdout instead of the default stderr
 	// Can be any io.Writer, see below for File example
-	f, _ := os.OpenFile(commons.DefaultLogFolder+"heimdall.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	f, _ := os.OpenFile(commons.DefaultLogFolder+"/heimdall.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	log.SetOutput(f)
 
 	// Only log the warning severity or above.

--- a/utils/trace.go
+++ b/utils/trace.go
@@ -2,11 +2,12 @@ package utils
 
 import (
 	"fmt"
+	"os"
+	"regexp"
+
 	"github.com/mitchellh/colorstring"
 	log "github.com/sirupsen/logrus"
 	"github.com/yodamad/heimdall/commons"
-	"os"
-	"regexp"
 )
 
 func Trace(msg string, isDebug bool) {
@@ -31,9 +32,9 @@ func OverrideLogFile() {
 		os.RemoveAll("heimdall.log")
 		f, _ := os.OpenFile(commons.LogDir+"/heimdall.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 		log.SetOutput(f)
-		Trace(colorstring.Color("📝 Log file written in [light_blue]"+commons.LogDir), false)
+		Trace(colorstring.Color("📝 Log file written in [light_blue]"+commons.LogDir+"/heimdall.log"), false)
 	} else {
-		Trace(colorstring.Color("📝 Log file written in [light_blue]"+commons.DefaultLogFolder), false)
+		Trace(colorstring.Color("📝 Log file written in [light_blue]"+commons.DefaultLogFolder+"/heimdall.log"), false)
 	}
 }
 


### PR DESCRIPTION
With commit https://github.com/yodamad/heimdall/commit/1d26743dae4947533f602645c94ccd6ce84bbb6a, on Linux logs must be saved by default in `~/.cache/heimdall.log` file.

But there is an error in this commit, forgot to add `/` for log file path => logs saved in `~/.cacheheimdall.log` :(
https://github.com/yodamad/heimdall/blob/343ab926b6b6b5a5610869c5c0d7993b65817cc4/main.go#L52

---
- On Linux, logs are in written by default in `~/.cache/heimdall.log` file.
- Improve output for logs file in `utils/trace.go`