### PR TITLE
Fix path for config directory on Linux

### DIFF
--- a/commons/const.go
+++ b/commons/const.go
@@ -13,8 +13,10 @@ var DefaultConfFolderFunc = func() string {
 	home, _ := os.UserConfigDir()
 	if runtime.GOOS == "darwin" {
 		home = os.Getenv("HOME")
+		return home + "/.heimdall/"
+	} else {
+		return home + "/heimdall/"
 	}
-	return home + "/.heimdall/"
 }
 
 // DefaultConfFolder DefaultFolder /* Default folder for git-info search */


### PR DESCRIPTION
With commit https://github.com/yodamad/heimdall/commit/1d26743dae4947533f602645c94ccd6ce84bbb6a, on Linux config file must be now read in `$HOME/.config/heimdall/` directory.

But there is an issue in this commit => config directory is `$HOME/.config/.heimdall/` (hidden directory on Linux).
https://github.com/yodamad/heimdall/blob/1d26743dae4947533f602645c94ccd6ce84bbb6a/commons/const.go#L12-L18

---
Fix path for config folder on Linux in `commons/const.go`