### PR TITLE
Fix outputs for version

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -20,9 +20,7 @@ func GetBuildInfos() goversion.Info {
 			if Date != "" {
 				i.BuildDate = Date
 			}
-			if Version != "dev" {
-				i.GitVersion = Version
-			}
+			i.GitVersion = Version
 		},
 	)
 }

--- a/utils/print.go
+++ b/utils/print.go
@@ -28,7 +28,7 @@ func PrintBanner() {
 		fmt.Printf(colorstring.Color("Version [bold][light_gray]%s[reset] (commit %s), built at %s, compiled with %s\n"),
 			build.BuildInfos.GitVersion, build.BuildInfos.GitCommit[:7], build.BuildInfos.BuildDate, build.BuildInfos.GoVersion)
 	} else {
-		fmt.Printf(colorstring.Color("Version [bold][light_gray]%s[reset]\n"), build.Version)
+		fmt.Printf(colorstring.Color("Version [bold][light_gray]%s[reset]\n"), build.BuildInfos.GitVersion)
 	}
 
 	fmt.Println("  ")


### PR DESCRIPTION
Fix yodamad/heimdall#32

---
**Tests OK with default version = `dev`**
```sh
$ ./heimdall foo
            _               _       _ _
  /\  /\___(_)_ __ ___   __| | __ _| | |
 / /_/ / _ \ | '_ ` _ \ / _` |/ _` | | |
/ __  /  __/ | | | | | | (_| | (_| | | |
\/ /_/ \___|_|_| |_| |_|\__,_|\__,_|_|_|

Version dev

$ ./heimdall env-info
            _               _       _ _
  /\  /\___(_)_ __ ___   __| | __ _| | |
 / /_/ / _ \ | '_ ` _ \ / _` |/ _` | | |
/ __  /  __/ | | | | | | (_| | (_| | | |
\/ /_/ \___|_|_| |_| |_|\__,_|\__,_|_|_|

Version dev (commit d311588), built at 2025-02-13T11:46:47, compiled with go1.23.6
  
+----------+----------+------------------------------------------+
| Heimdall |          |                                          |
|          | version  | dev                                      |
|          | commit   | d311588fb5cbdfbd40108b240ff6fc40f2aa803c |
+----------+----------+------------------------------------------+
| OS       |          |                                          |
|          | type     | linux                                    |
|          | arch     | x86_64                                   |
|          | platform | debian                                   |
|          | family   | debian                                   |
|          | version  | trixie/sid                               |
+----------+----------+------------------------------------------+
| CPU      |          |                                          |
|          | cpu      | Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz  |
|          | model    | 60                                       |
|          | family   | 6                                        |
+----------+----------+------------------------------------------+
```

**Tests OK with build + ldflags**
```sh
$ go build -v -ldflags '-X github.com/yodamad/heimdall/build.Version=0.5.x'

$ ./heimdall foo
            _               _       _ _
  /\  /\___(_)_ __ ___   __| | __ _| | |
 / /_/ / _ \ | '_ ` _ \ / _` |/ _` | | |
/ __  /  __/ | | | | | | (_| | (_| | | |
\/ /_/ \___|_|_| |_| |_|\__,_|\__,_|_|_|

Version 0.5.x

$ ./heimdall env-info
            _               _       _ _
  /\  /\___(_)_ __ ___   __| | __ _| | |
 / /_/ / _ \ | '_ ` _ \ / _` |/ _` | | |
/ __  /  __/ | | | | | | (_| | (_| | | |
\/ /_/ \___|_|_| |_| |_|\__,_|\__,_|_|_|

Version 0.5.x (commit d311588), built at 2025-02-13T11:46:47, compiled with go1.23.6
  
+----------+----------+------------------------------------------+
| Heimdall |          |                                          |
|          | version  | 0.5.x                                    |
|          | commit   | d311588fb5cbdfbd40108b240ff6fc40f2aa803c |
+----------+----------+------------------------------------------+
| OS       |          |                                          |
|          | type     | linux                                    |
|          | arch     | x86_64                                   |
|          | platform | debian                                   |
|          | family   | debian                                   |
|          | version  | trixie/sid                               |
+----------+----------+------------------------------------------+
| CPU      |          |                                          |
|          | cpu      | Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz  |
|          | model    | 60                                       |
|          | family   | 6                                        |
+----------+----------+------------------------------------------+
```
