### PR TITLE
Fix output for default logs file

### DIFF
--- a/utils/trace.go
+++ b/utils/trace.go
@@ -34,7 +34,7 @@ func OverrideLogFile() {
 		log.SetOutput(f)
 		Trace(colorstring.Color("📝 Log file written in [light_blue]"+commons.LogDir+"/heimdall.log"), false)
 	} else {
-		Trace(colorstring.Color("📝 Log file written in [light_blue]"+commons.DefaultLogFolder+"/heimdall.log"), false)
+		Trace(colorstring.Color("📝 Log file written in [light_blue]"+commons.DefaultLogFolder+"heimdall.log"), false)
 	}
 }
 


### PR DESCRIPTION
Without this fix, output for logs file = `$HOME/.cache/heimdall//heimdall.log` => double `/`

```sh
$ ./heimdall -v gi -w <Git repository>
⚠ Platform github.com is not correctly configured : missing token field. Ignoring it...
            _               _       _ _
  /\  /\___(_)_ __ ___   __| | __ _| | |
 / /_/ / _ \ | '_ ` _ \ / _` |/ _` | | |
/ __  /  __/ | | | | | | (_| | (_| | | |
\/ /_/ \___|_|_| |_| |_|\__,_|\__,_|_|_|

Version dev (commit 2dd6faf), built at 2025-02-13T17:15:52, compiled with go1.23.6
  
📝 Log file written in /home/fox/.cache/heimdall//heimdall.log
(...)
```