### PR TITLE
Improve outputs

### DIFF
--- a/utils/print.go
+++ b/utils/print.go
@@ -49,6 +49,7 @@ func PrintBannerWithoutColor() {
 \/ /_/ \___|_|_| |_| |_|\__,_|\__,_|_|_|
 `,
 	)
+	fmt.Println()
 
 	if commons.Verbose {
 		fmt.Printf("Version %s (commit %s), built at %s, compiled with %s\n",

--- a/utils/trace.go
+++ b/utils/trace.go
@@ -25,9 +25,9 @@ func Trace(msg string, isDebug bool) {
 func TraceWarn(msg string) {
 	if commons.NoColor {
 		msg = CleanForLog(msg)
-		fmt.Println("⚠ " + msg)
+		fmt.Println("⚠  " + msg)
 	} else {
-		fmt.Println(ColorString("[light_yellow]⚠ " + msg + "[default]"))
+		fmt.Println(ColorString("[light_yellow]⚠  " + msg + "[default]"))
 	}
 	log.Info(CleanForLog(msg))
 }


### PR DESCRIPTION
- utils/print.go: add newline to display banner without colors
- utils/trace.go: add space after icon in warning logs